### PR TITLE
Pin zig to 0.14.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,4 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.14.1
       - run: zig build test


### PR DESCRIPTION
Pin zig to 0.14.1 until homebrew is updated to 0.15. See https://github.com/Homebrew/homebrew-core/pull/234255